### PR TITLE
Adding the option to add unsubscribe links before the footer

### DIFF
--- a/openedx_email_extensions/locale/ar/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/ar/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-14 18:30-0500\n"
 "Last-Translator: \n"
 "Language: ar\n"
@@ -51,6 +51,10 @@ msgstr "تم إنشاء هذه الرسالة تلقائيا."
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
 msgstr "حركة"
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
+msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11
 msgid "Account activation"

--- a/openedx_email_extensions/locale/da/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/da/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-14 17:55-0500\n"
 "Last-Translator: \n"
 "Language: da\n"
@@ -50,6 +50,10 @@ msgstr "Denne besked er automatisk genereret."
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
 msgstr "Handling"
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
+msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11
 msgid "Account activation"

--- a/openedx_email_extensions/locale/de_DE/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/de_DE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de_DE\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/en/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/es_419/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/es_419/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-14 17:02-0500\n"
 "Last-Translator: \n"
 "Language: es_419\n"
@@ -50,6 +50,10 @@ msgstr "Este mensaje fue generado automáticamente."
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
 msgstr "Acción"
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
+msgstr "Modifique su subscripción aquí"
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11
 msgid "Account activation"

--- a/openedx_email_extensions/locale/fr/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/he/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/he/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: he\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/it_IT/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/it_IT/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: it_IT\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/ja_JP/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/ja_JP/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja_JP\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/ko_KR/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/ko_KR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ko_KR\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/pt_BR/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/pt_BR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt_BR\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/ru/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/ru/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -48,6 +48,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/zh_CN/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/zh_CN/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_Hans_CN\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/locale/zh_TW/LC_MESSAGES/django.po
+++ b/openedx_email_extensions/locale/zh_TW/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: support@edunext.co\n"
-"POT-Creation-Date: 2016-11-15 12:33-0500\n"
+"POT-Creation-Date: 2016-11-15 14:35-0500\n"
 "PO-Revision-Date: 2016-10-07 18:00-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_Hant_TW\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: openedx_email_extensions/templates/email_layout/one_call_to_action.html:47
 msgid "Action"
+msgstr ""
+
+#: openedx_email_extensions/templates/email_layout/unsubscribe_links.html:7
+msgid "Unsubscribe here"
 msgstr ""
 
 #: openedx_email_extensions/templates/emails/activation_email.html:11

--- a/openedx_email_extensions/settings.py
+++ b/openedx_email_extensions/settings.py
@@ -44,6 +44,7 @@ DEFAULT_EMAIL_COLORS = {
 }
 
 DEFAULT_EMAIL_LOGO_PATH = "http://placehold.it/600x142"
+DEFAULT_EMAIL_UNSUBSCRIBE_LINKS = False
 
 
 class ProxySettings(object):

--- a/openedx_email_extensions/templates/email_layout/mc_base.html
+++ b/openedx_email_extensions/templates/email_layout/mc_base.html
@@ -138,6 +138,13 @@ from openedx_email_extensions.utils import template_path_finder
                                 <%include file="${ template_path_finder(extra_footer_template) }" />
                               % endif
 
+                              <%
+                                unsubscribe_links = proxy_settings.EMAIL_UNSUBSCRIBE_LINKS
+                              %>
+                              % if unsubscribe_links:
+                                <%include file="${ template_path_finder('/email_layout/unsubscribe_links.html') }" />
+                              % endif
+
                               <center data-parsed="" style="min-width:432px;width:100%">
                                 <table align="center" class="menu float-center" style="border-collapse:collapse;border-spacing:0;float:none;margin:0 auto;padding:0;text-align:center;vertical-align:top;width:auto!important">
                                   <tbody>

--- a/openedx_email_extensions/templates/email_layout/unsubscribe_links.html
+++ b/openedx_email_extensions/templates/email_layout/unsubscribe_links.html
@@ -1,0 +1,8 @@
+## mako
+<%!
+  from django.utils.translation import ugettext as _
+%>
+<center data-parsed=\"\" style=\"width:100%;\">
+  <p class=\"text-center float-center\" style=\"color:#B1B1B1;font-family:Helvetica,Arial,sans-serif;font-size:11px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:center; margin-top: 25px;\">
+  <a href="%tag_unsubscribe_url%" style="font-family:Helvetica,Arial,sans-serif;font-weight:400;line-height:1.3;margin:0;padding:0;text-align:left;text-decoration:none">${_("Unsubscribe here")}</a></p>
+</center>


### PR DESCRIPTION
This adds the option to generate unsubscribe links at the html.
It is not required to have them, since we send only transactional email, but having this, should help to raise the sending domain reputation.

@juancamilom 

We still need to have the markup checked by @Bound3R 

