### PR TITLE
Jhony/fix i18n files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE.txt
 include README.rst
-recursive-include openedx_email_extensions *.html *.png *.gif *js *.css *jpg *jpeg *svg *py
+recursive-include openedx_email_extensions *.html *.png *.gif *js *.css *jpg *jpeg *svg *py *.po *.mo

--- a/openedx_email_extensions/__init__.py
+++ b/openedx_email_extensions/__init__.py
@@ -4,6 +4,6 @@ A package to make the outgoing emails in open-edx good looking..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 default_app_config = 'openedx_email_extensions.apps.OpenedxEmailExtensionsConfig'  # pylint: disable=invalid-name

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 
 [wheel]
 universal = 1


### PR DESCRIPTION
This PR adds the extensions po and mo to the MANIFEST.in file, which determines what kind of files are included in the package installation. This is the reason why locale folder was not included.

@juancamilom 
@felipemontoya 